### PR TITLE
[DO NOT WORK] xlmroberta embedding

### DIFF
--- a/convert-hf-to-gguf-update.py
+++ b/convert-hf-to-gguf-update.py
@@ -86,6 +86,7 @@ models = [
     {"name": "poro-chat",      "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/LumiOpen/Poro-34B-chat", },
     {"name": "jina-v2-code",   "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/jinaai/jina-embeddings-v2-base-code", },
     {"name": "viking",         "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/LumiOpen/Viking-7B", }, # Also used for Viking 13B and 33B
+    {"name": "multilingual-e5","tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/intfloat/multilingual-e5-large-instruct", },
 ]
 
 

--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -457,18 +457,12 @@ class Model:
         if chkhsh == "6221ad2852e85ce96f791f476e0b390cf9b474c9e3d1362f53a24a06dc8220ff":
             # ref: https://huggingface.co/smallcloudai/Refact-1_6-base
             res = "refact"
-        if chkhsh == "9c2227e4dd922002fb81bde4fc02b0483ca4f12911410dee2255e4987644e3f8":
-            # ref: https://huggingface.co/CohereForAI/c4ai-command-r-v01
-            res = "command-r"
         if chkhsh == "e636dc30a262dcc0d8c323492e32ae2b70728f4df7dfe9737d9f920a282b8aea":
             # ref: https://huggingface.co/Qwen/Qwen1.5-7B
             res = "qwen2"
         if chkhsh == "b6dc8df998e1cfbdc4eac8243701a65afe638679230920b50d6f17d81c098166":
             # ref: https://huggingface.co/allenai/OLMo-1.7-7B-hf
             res = "olmo"
-        if chkhsh == "a8594e3edff7c29c003940395316294b2c623e09894deebbc65f33f1515df79e":
-            # ref: https://huggingface.co/databricks/dbrx-base
-            res = "dbrx"
         if chkhsh == "0876d13b50744004aa9aeae05e7b0647eac9d801b5ba4668afc01e709c15e19f":
             # ref: https://huggingface.co/jinaai/jina-embeddings-v2-base-en
             res = "jina-v2-en"
@@ -490,6 +484,9 @@ class Model:
         if chkhsh == "7fc505bd3104ca1083b150b17d088b59534ede9bde81f0dd2090967d7fe52cee":
             # ref: https://huggingface.co/LumiOpen/Viking-7B
             res = "viking"
+        if chkhsh == "a81863d07e75497e2194eb1a1574d5e5cd4d5f85a87a0728b922bf2bed6fb327":
+            # ref: https://huggingface.co/intfloat/multilingual-e5-large-instruct
+            res = "multilingual-e5"
 
         if res is None:
             logger.warning("\n")
@@ -2189,7 +2186,7 @@ in chat mode so that the conversation can end normally.")
             return [(self.map_tensor_name(name), data_torch)]
 
 
-@Model.register("BertModel", "CamembertModel")
+@Model.register("BertModel", "CamembertModel", "XLMRobertaModel")
 class BertModel(Model):
     model_arch = gguf.MODEL_ARCH.BERT
 
@@ -2230,7 +2227,7 @@ class BertModel(Model):
 
         # we need this to validate the size of the token_type embeddings
         # though currently we are passing all zeros to the token_type embeddings
-        self.gguf_writer.add_token_type_count(2)  # "Sequence A" or "Sequence B"
+        self.gguf_writer.add_token_type_count(1)  # "Sequence A" or "Sequence B"
 
         # convert to phantom space vocab
         def phantom(tok):

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,6 +12,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 if (EMSCRIPTEN)
 else()
+    add_subdirectory(aizip-test)
     add_subdirectory(cvector-generator)
     add_subdirectory(baby-llama)
     add_subdirectory(batched-bench)

--- a/examples/aizip-test/CMakeLists.txt
+++ b/examples/aizip-test/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(TARGET aizip-test)
+add_executable(${TARGET} main.cpp)
+install(TARGETS ${TARGET} RUNTIME)
+target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT})
+target_compile_features(${TARGET} PRIVATE cxx_std_11)

--- a/examples/aizip-test/main.cpp
+++ b/examples/aizip-test/main.cpp
@@ -1,0 +1,89 @@
+#include "common.h"
+#include "llama.h"
+
+// const char* MODEL_PATH = "models/full/bge-small-en-v1.5.gguf";
+const char* MODEL_PATH = "models/full/multilingual-e5-large-instruct-f16.gguf";
+
+int main() {
+    llama_backend_init();
+
+    llama_model_params params = llama_model_default_params();
+    llama_model* model = llama_load_model_from_file(MODEL_PATH, params);
+    GGML_ASSERT(model);
+
+    llama_context_params cparams = llama_context_default_params();
+    cparams.n_batch = 2048;
+    cparams.n_ubatch = 2048;
+    cparams.embeddings = true;
+    llama_context* ctx = llama_new_context_with_model(model, cparams);
+    GGML_ASSERT(ctx);
+
+    std::vector<std::vector<int32_t>> inputs;
+    // inputs.push_back({101, 7592, 1010, 2088, 999, 102}); // bert-bge
+    inputs.push_back({0, 35378,     4,  8999,    38,     2}); // multilingual
+
+    // check if the last token is SEP
+    for (auto & inp : inputs) {
+        if (inp.empty() || inp.back() != llama_token_sep(model)) {
+            fprintf(stderr, "%s: warning: last token in the prompt is not SEP\n", __func__);
+        }
+    }
+
+
+    const int n_batch = cparams.n_batch;
+
+    llama_kv_cache_clear(ctx);
+
+    const int n_prompts = inputs.size();
+    llama_batch batch = llama_batch_init(n_batch, 0, 1);
+
+    const int n_embd = llama_n_embd(model);
+    std::vector<float> embeddings(n_prompts * n_embd, 0.0f);
+    float* emb = embeddings.data();
+
+    int s = 0;
+    for (int k = 0; k < n_prompts; k++) {
+        // clamp to n_batch tokens
+        auto& inp = inputs[k];
+
+        GGML_ASSERT(batch.n_tokens + (int)inp.size() <= n_batch);
+
+        for (size_t i = 0; i < inp.size(); i++) {
+            bool is_last = (i == inp.size() - 1);
+            llama_batch_add(batch, inp[i], i, {0}, is_last);
+        }
+    }
+
+    fprintf(stderr, "%s: n_tokens = %d\n", __func__, batch.n_tokens);
+    if (llama_decode(ctx, batch) < 0) {
+        GGML_ASSERT(false);
+    }
+
+    for (int i = 0; i < batch.n_tokens; i++) {
+        if (!batch.logits[i]) {
+            continue;
+        }
+
+        const float * embd = llama_get_embeddings_seq(ctx, batch.seq_id[i][0]);
+        if (embd == NULL) {
+            embd = llama_get_embeddings_ith(ctx, i);
+        }
+        GGML_ASSERT(embd);
+
+        
+
+        fprintf(stdout, "unnormalized embedding:");
+        for (int hh = 0; hh < n_embd; hh++) {
+            fprintf(stdout, "%9.6f ", embd[hh]);
+        }
+        fprintf(stdout, "\n");
+
+        float* out = emb + batch.seq_id[i][0] * n_embd;
+        llama_embd_normalize(embd, out, n_embd);
+        fprintf(stdout, "normalized embedding:");
+        for (int hh = 0; hh < n_embd; hh++) {
+            fprintf(stdout, "%9.6f ", out[hh]);
+        }
+        fprintf(stdout, "\n");
+    }
+}

--- a/examples/aizip-test/main.cpp
+++ b/examples/aizip-test/main.cpp
@@ -48,9 +48,18 @@ int main() {
 
         GGML_ASSERT(batch.n_tokens + (int)inp.size() <= n_batch);
 
+        int token_count = 0;
         for (size_t i = 0; i < inp.size(); i++) {
             bool is_last = (i == inp.size() - 1);
-            llama_batch_add(batch, inp[i], i, {0}, is_last);
+            if (inp[i]==1)// This is padding token
+            {
+                llama_batch_add(batch, inp[i], 1, {0}, is_last);
+            }
+            else
+            {
+                llama_batch_add(batch, inp[i], token_count+2, {0}, is_last);
+                token_count++;
+            }
         }
     }
 
@@ -74,16 +83,16 @@ int main() {
 
         fprintf(stdout, "unnormalized embedding:");
         for (int hh = 0; hh < n_embd; hh++) {
-            fprintf(stdout, "%9.6f ", embd[hh]);
+            fprintf(stdout, "%9.6f,", embd[hh]);
         }
         fprintf(stdout, "\n");
 
-        float* out = emb + batch.seq_id[i][0] * n_embd;
-        llama_embd_normalize(embd, out, n_embd);
-        fprintf(stdout, "normalized embedding:");
-        for (int hh = 0; hh < n_embd; hh++) {
-            fprintf(stdout, "%9.6f ", out[hh]);
-        }
-        fprintf(stdout, "\n");
+        // float* out = emb + batch.seq_id[i][0] * n_embd;
+        // llama_embd_normalize(embd, out, n_embd);
+        // fprintf(stdout, "normalized embedding:");
+        // for (int hh = 0; hh < n_embd; hh++) {
+        //     fprintf(stdout, "%9.6f ", out[hh]);
+        // }
+        // fprintf(stdout, "\n");
     }
 }

--- a/examples/embedding/embedding.cpp
+++ b/examples/embedding/embedding.cpp
@@ -128,6 +128,14 @@ int main(int argc, char ** argv) {
         inputs.push_back(inp);
     }
 
+    for (int j = 0; j < prompts.size(); j++) {
+        printf("embedding %d: ", j);
+        for (auto tok : inputs[j]) {
+            printf("%d, ", tok);
+        }
+        printf("\n");
+    }
+
     // check if the last token is SEP
     // it should be automatically added by the tokenizer when 'tokenizer.ggml.add_eos_token' is set to 'true'
     for (auto & inp : inputs) {

--- a/test.py
+++ b/test.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import os
+from transformers import AutoTokenizer, AutoModel
+import torch
+import numpy as np
+
+# os.environ['https_proxy'] = 'http://127.0.0.1:1081'
+
+# MODEL_NAME = 'BAAI/bge-small-en-v1.5'
+MODEL_NAME = 'intfloat/multilingual-e5-large-instruct'
+
+sentences = ["Hello, world!"]
+tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+model = AutoModel.from_pretrained(MODEL_NAME)
+model.eval()
+
+encoded_input = tokenizer(sentences, padding=True, truncation=True, return_tensors='pt')
+# for s2p(short query to long passage) retrieval task, add an instruction to query (not add instruction for passages)
+# encoded_input = tokenizer([instruction + q for q in queries], padding=True, truncation=True, return_tensors='pt')
+print(encoded_input)
+
+# Compute token embeddings
+with torch.no_grad():
+    model_output = model(**encoded_input)
+    # Perform pooling. In this case, cls pooling.
+    sentence_embeddings = model_output.last_hidden_state[:, 0, :]
+# normalize embeddings
+# sentence_embeddings = torch.nn.functional.normalize(sentence_embeddings, p=2, dim=1)
+formatter = {
+    'float_kind': lambda x: f'{x:.5f}'
+}
+print("unnormalized embeddings:", np.array2string(sentence_embeddings.numpy(), threshold=1024, formatter=formatter))


### PR DESCRIPTION
The PR intend to add support  for `intfloat/multilingual-e5-large-instruct`. However, it's far from complete. I post it here for discussion only.

* Changes to `convet-hf-to-gguf-update.py`/`convert-hf-to-gguf.py`:

These changes make sure the multilingual-e5 model can be converted to gguf, however, the converted model currently does not work.

Even the tokenizer part seems completely broken, we need to include a tokenizer to make llama.cpp happy (even we currently do not use it)

You may use `build/bin/llama-tokenize -m <model-path> -p "Hello, world!` to test tokenizer.

**NOTE**: the changes are very ad-hoc. It will **break** `BAAI/bge-small-en-v1.5` model conversion since it changes `self.gguf_writer.add_token_type_count` unconditionally. It's for testing purpose only.

* `test.py`: convenience script to print out token list and embedding vector generated by huggingface

You may change the model, the input, or switch between unnormalized/normalized embedding vector by directly editing the code.

* `examples/embedding/embedding.cpp`: print the token list for debugging purpose.

Usage: `build/bin/llama-embedding -m <model-path> -p "Hello, world!"

* `examples/aizip-test/main.cpp`: a simplified version of the embedding example.

Due to the XLMRobertaTokenizer does not work on llama.cpp. I create a new embedding example bypass the tokenization stage. The token list is hardcoded in the source. The token list may be generated by `test.py`.

**NOTE**: when you switch the model, DO NOT FORGET to switch the input token list correspondingly. 
